### PR TITLE
Only returns events since registration.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,4 +42,12 @@ class ApplicationController < ActionController::API
   def user_id
     jwt_payload['data']['id'].to_s
   end
+
+  def current_registered_user
+    @current_registered_user ||= RegisteredUser.find_by(user_id: user_id)
+  end
+
+  def require_registered_user
+    render_unauthorized unless current_registered_user
+  end
 end

--- a/app/controllers/ifttt/v1/triggers/loved_a_post_controller.rb
+++ b/app/controllers/ifttt/v1/triggers/loved_a_post_controller.rb
@@ -1,4 +1,6 @@
 class Ifttt::V1::Triggers::LovedAPostController < ApplicationController
+  before_action :require_registered_user
+
   def index
     render json: { data: events.map { |e| to_json(e) } }
   end
@@ -6,7 +8,7 @@ class Ifttt::V1::Triggers::LovedAPostController < ApplicationController
   private
 
   def events
-    Event.where(
+    Event.where('created_at >= ?', current_registered_user.created_at).where(
       kind: 'post_was_loved',
       action_taken_by_id: user_id,
     ).order('created_at DESC').limit(limit)

--- a/app/controllers/ifttt/v1/triggers/submitted_new_post_controller.rb
+++ b/app/controllers/ifttt/v1/triggers/submitted_new_post_controller.rb
@@ -1,4 +1,6 @@
 class Ifttt::V1::Triggers::SubmittedNewPostController < ApplicationController
+  before_action :require_registered_user
+
   def index
     render json: { data: events.map { |e| to_json(e) } }
   end
@@ -6,7 +8,7 @@ class Ifttt::V1::Triggers::SubmittedNewPostController < ApplicationController
   private
 
   def events
-    Event.where(
+    Event.where('created_at >= ?', current_registered_user.created_at).where(
       kind:  'post_was_created',
       owner_id: user_id,
     ).order('created_at DESC').limit(limit)

--- a/spec/request/loved_a_post_spec.rb
+++ b/spec/request/loved_a_post_spec.rb
@@ -75,24 +75,55 @@ RSpec.describe 'Fetching loved post triggers', type: :request do
         action_taken_by_id: '2'
       )
     end
-
-    before do
-      post '/ifttt/v1/triggers/loved_a_post',
-           params: params,
-           headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+    let!(:pl_old) do
+      Event.create!(
+        owner_id: '2',
+        payload: {
+          post: {
+            id: 1,
+            url: 'https://ello.co/lana/posts/1'
+          },
+          loved_at: 2.days.ago
+        },
+        created_at: 2.days.ago,
+        kind: 'post_was_loved',
+        action_taken_by_id: '1'
+      )
     end
 
-    it 'returns a JSON hash of the most recent events by the jwt user' do
-      expect(response.status).to eq(200)
-      expect(response_json['data'].size).to eq 2
-      expect(response_json['data'].first).to eq(
-        'post_url' => 'https://ello.co/lana/posts/2',
-        'loved_at' => pl2.payload['loved_at'].to_time.iso8601,
-        'meta' => {
-          'id' => pl2.id,
-          'timestamp' => pl2.created_at.to_i
-        }
-      )
+    context 'without a registered user' do
+      before do
+        post '/ifttt/v1/triggers/loved_a_post',
+             params: params,
+             headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+      end
+
+      it 'returns 401' do
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with a registered user' do
+      before { RegisteredUser.create(user_id: 1, created_at: 12.hours.ago) }
+
+      before do
+        post '/ifttt/v1/triggers/loved_a_post',
+             params: params,
+             headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+      end
+
+      it 'returns a JSON hash of the most recent events by the jwt user' do
+        expect(response.status).to eq(200)
+        expect(response_json['data'].size).to eq 2
+        expect(response_json['data'].first).to eq(
+          'post_url' => 'https://ello.co/lana/posts/2',
+          'loved_at' => pl2.payload['loved_at'].to_time.iso8601,
+          'meta' => {
+            'id' => pl2.id,
+            'timestamp' => pl2.created_at.to_i
+          }
+        )
+      end
     end
   end
 end

--- a/spec/request/submitted_new_post_spec.rb
+++ b/spec/request/submitted_new_post_spec.rb
@@ -63,24 +63,48 @@ RSpec.describe 'Fetching new post triggers', type: :request do
         action_taken_by_id: '2'
       )
     end
-
-    before do
-      post '/ifttt/v1/triggers/submitted_new_post',
-           params: params,
-           headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+    let!(:pc_old) do
+      Event.create!(
+        owner_id: '1',
+        payload: { post: { id: 1, url: 'https://ello.co/archer/posts/1' } },
+        created_at: 2.days.ago,
+        kind: 'post_was_created',
+        action_taken_by_id: '1'
+      )
     end
 
-    it 'returns a JSON hash of the most recent events by the jwt user' do
-      expect(response.status).to eq(200)
-      expect(response_json['data'].size).to eq 2
-      expect(response_json['data'].first).to eq(
-        'post_url' => 'https://ello.co/archer/posts/2',
-        'created_at' => pc2.created_at.to_time.iso8601,
-        'meta' => {
-          'id' => pc2.id,
-          'timestamp' => pc2.created_at.to_i
-        }
-      )
+    context 'without a registered user' do
+      before do
+        post '/ifttt/v1/triggers/submitted_new_post',
+             params: params,
+             headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+      end
+
+      it 'should return 401' do
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with a registered user' do
+      before { RegisteredUser.create(user_id: 1, created_at: 12.hours.ago) }
+      before do
+        post '/ifttt/v1/triggers/submitted_new_post',
+             params: params,
+             headers: { 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
+      end
+
+      it 'returns a JSON hash of the most recent events by the jwt user' do
+        expect(response.status).to eq(200)
+        expect(response_json['data'].size).to eq 2
+        expect(response_json['data'].first).to eq(
+          'post_url' => 'https://ello.co/archer/posts/2',
+          'created_at' => pc2.created_at.to_time.iso8601,
+          'meta' => {
+            'id' => pc2.id,
+            'timestamp' => pc2.created_at.to_i
+          }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This prevents any possibility of a user signing up for the first time
and getting lots of trigger notifications.